### PR TITLE
ci: run the test suite on GitHub Actions, incl. a non-UTF-8 locale job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,75 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: ${{ matrix.os }} / py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # README declares Python 3.10+, so the matrix pins the floor and a
+        # current release. Windows is here on purpose: every encoding bug this
+        # suite guards against only reproduces off a UTF-8 default.
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.10', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install test dependencies
+        # flask/flask-cors: several tests import dnd-display-app.py directly.
+        # pyyaml: graph_extract_deterministic.py sys.exit(2)s at import without
+        # it, which crashes pytest's collector with INTERNALERROR rather than a
+        # readable failure. It is NOT in display/requirements.txt.
+        # pygame and numpy are in display/requirements.txt but are runtime-only
+        # (dice server, TTS) and cost real build time, so they stay out.
+        run: python -m pip install --upgrade pip pytest flask flask-cors pyyaml
+      - name: pytest
+        run: python -m pytest tests/ -q
+
+  ascii-locale:
+    # The encoding bug class, measured behaviourally instead of by reading
+    # source. The suite's own fixtures are ASCII, but the SOURCE and data files
+    # are full of UTF-8, so a non-UTF-8 default codepage fails on import and on
+    # every bare read. This is the same failure a cp936 (Chinese) or cp1251
+    # (Russian) Windows console produces, in the strictest form available on a
+    # Linux runner.
+    name: non-UTF-8 locale (ubuntu / py3.13)
+    runs-on: ubuntu-latest
+    env:
+      LC_ALL: C
+      LANG: C
+      PYTHONUTF8: '0'
+      # PEP 538 coerces the C locale to C.UTF-8 on Linux, which would make this
+      # job pass without ever testing anything. Disabling it is what gives the
+      # job its teeth.
+      PYTHONCOERCECLOCALE: '0'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest flask flask-cors pyyaml
+      - name: Assert the locale really is non-UTF-8
+        # Without this, a future runner that coerces the locale anyway would
+        # turn the job below into a green light that measures nothing.
+        run: |
+          python - <<'PY'
+          import locale, sys
+          enc = locale.getpreferredencoding(False)
+          print(f"preferred={enc}  stdout={sys.stdout.encoding}")
+          if "utf" in enc.lower():
+              sys.exit("locale was coerced to UTF-8 — this job would pass vacuously")
+          PY
+      - name: pytest under an ASCII locale
+        run: python -m pytest tests/ -q


### PR DESCRIPTION
There was no CI in this repo, so nothing ran the test suite except whoever remembered to. That's the same gap `tests/test_encoding_tree.py` in #63 was written to close, one level up: a guard nobody runs is a guard that isn't there.

Two jobs.

**`tests`** runs the suite on ubuntu, macos and windows across py3.10 (the floor the README declares) and py3.13.

**`ascii-locale`** runs the same suite under `LC_ALL=C` with PEP 538 coercion disabled. The encoding bug class in #63 and #34 does not reproduce on a UTF-8 default, which is how it survived long enough to reach us as a user report from a cp936 console. The suite's own fixtures are all ASCII, but the source and data files are full of UTF-8, so a non-UTF-8 default fails on import and on every bare read.

Both halves measured, by running this matrix against #63's code before deciding merge order:

| job | this commit | with #63 |
|---|---|---|
| ubuntu 3.10 / 3.13 | pass | pass |
| macos 3.10 / 3.13 | pass | pass |
| windows 3.10 / 3.13 | **8 failed** | pass |
| ascii-locale | **31 failed, 12 errors** | pass |

Every Windows failure and every ascii-locale failure is a `UnicodeDecodeError`, so there's no incidental noise in either signal. These are behavioural checks rather than source scans, which means they measure the property that actually matters instead of the shape of the code.

Worth recording: the Windows failures come out of `cp1252.py`, and cp1252 is the US-English codepage. This was never a Chinese Windows problem or even a non-English one. It fails on a stock English Windows install, so it has been affecting every Windows user since launch, and only showed up in reports from people whose content was non-ASCII enough to make it visible.

The `ascii-locale` job asserts its own premise before running anything. PEP 538 coerces the C locale to C.UTF-8 on Linux, and without the assertion a runner that did that would turn the whole job into a green light measuring nothing.

Note this means main goes red until #63 lands. That's accurate rather than unfortunate, and it's the shortest path to main being green for real. Nothing is configured as a required status check, so it blocks no merges in the meantime.

Dependencies are installed explicitly rather than from `display/requirements.txt`, because that file is wrong in both directions and I'd rather fix it separately than bundle it here. `pyyaml` is missing from it and isn't optional: `graph_extract_deterministic.py` calls `sys.exit(2)` at import without it, which crashes pytest's collector with `INTERNALERROR` rather than a readable failure, so anyone setting up from the README hits a wall of traceback. `pygame` and `numpy` are listed there but are runtime-only for the dice server and TTS, and cost real build time.
